### PR TITLE
Flexible python path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,64 +1,65 @@
----
-- name: Show use_python3 variable
-  debug:
+--- 
+- 
+  debug: 
     msg: "Use Python3: {{ use_python3 }}"
-
-- name: Set defaults
-  set_fact:    
+  name: "Show use_python3 variable"
+- 
+  name: "Set defaults"
+  set_fact: 
     python_executable_path: "{{python_executable_path | default('/usr/bin/') }}"
-    
-- name: Set APT package for python3	
-  set_fact:
+- 
+  name: "Set APT package for python3"
+  set_fact: 
     package_to_install: "{{package_to_install | default('python3-pip')}}"
     pip_executable: "{{pip_executable | default('pip3')}}"
     python_executable: "{{python_executable | default('python3')}}"
-  when: 	
-    - "use_python3|bool"	
-    - ansible_pkg_mgr == 'apt'	
-    - "not only_python2|bool"	
-
-- name: Set YUM package for python3	
-  set_fact:	
-    package_to_install: "{{package_to_install | default('python3-pip')}}"
-    pip_executable: "{{pip_executable | default('pip3')}}"
-    python_executable: "{{python_executable | default('python3')}}"
-  when: 	
-    - "use_python3|bool"	
-    - ansible_pkg_mgr == 'yum'	
+  when: 
+    - use_python3|bool
+    - "ansible_pkg_mgr == 'apt'"
     - "not only_python2|bool"
-    
-- name: Set package for python2
-  set_fact:
+- 
+  name: "Set YUM package for python3"
+  set_fact: 
+    package_to_install: "{{package_to_install | default('python3-pip')}}"
+    pip_executable: "{{pip_executable | default('pip3')}}"
+    python_executable: "{{python_executable | default('python3')}}"
+  when: 
+    - use_python3|bool
+    - "ansible_pkg_mgr == 'yum'"
+    - "not only_python2|bool"
+- 
+  name: "Set package for python2"
+  set_fact: 
     package_to_install: "{{package_to_install | default('python-pip')}}"
     pip_executable: "{{pip_executable | default('pip2')}}"
-    python_executable: "{{python_executable | default('python2')}}"    
+    python_executable: "{{python_executable | default('python2')}}"
   when: "(not use_python3|bool or only_python2|bool)"
-
-- name: Detect pip installation
+- 
+  name: "Detect pip installation"
+  register: pip_installed
   stat: 
     path: "{{python_executable_path}}{{ pip_executable }}"
-  register: pip_installed
-
-- name: Install on Apt based system
+- 
   include: install-apt.yml
+  name: "Install on Apt based system"
   when: 
-    - ansible_pkg_mgr == 'apt'
-    - pip_installed.stat.exists == false
-
-- name: Install on Yum based system
+    - "ansible_pkg_mgr == 'apt'"
+    - "pip_installed.stat.exists == false"
+- 
   include: install-yum.yml
-  when:
-    - ansible_pkg_mgr == 'yum'
-    - pip_installed.stat.exists == false
-
-- name: Upgrade pip with pip
-  pip:
+  name: "Install on Yum based system"
+  when: 
+    - "ansible_pkg_mgr == 'yum'"
+    - "pip_installed.stat.exists == false"
+- 
+  name: "Upgrade pip with pip"
+  pip: 
+    executable: "{{python_executable_path}}{{ pip_executable }}"
     name: pip
     state: latest
+- 
+  name: "Install virtualenv"
+  pip: 
     executable: "{{python_executable_path}}{{ pip_executable }}"
-
-- name: Install virtualenv
-  pip:
     name: virtualenv
     state: present
-    executable: "{{python_executable_path}}{{ pip_executable }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 - 
   name: "Set defaults"
   set_fact:     
-    pip_executable_path: "{{python_executable_path | default('/usr/bin/') }}"
+    pip_executable_path: "{{pip_executable_path | default('/usr/bin/') }}"
 - 
   name: "Set APT package for python3"
   set_fact: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,36 +3,40 @@
   debug:
     msg: "Use Python3: {{ use_python3 }}"
 
-- name: Set APT package for python3
+- name: Set defaults
+  set_fact:    
+    python_executable_path: "{{python_executable_path | default('/usr/bin/') }}"
+    
+- name: Set APT package for python3	
   set_fact:
-    package_to_install: "python3-pip"
-    pip_executable: "pip3"
-    python_executable: "python3"
-  when: 
-    - "use_python3|bool"
-    - ansible_pkg_mgr == 'apt'
-    - "not only_python2|bool"
+    package_to_install: "{{package_to_install | default('python3-pip')}}"
+    pip_executable: "{{pip_executable | default('pip3')}}"
+    python_executable: "{{python_executable | default('python3')}}"
+  when: 	
+    - "use_python3|bool"	
+    - ansible_pkg_mgr == 'apt'	
+    - "not only_python2|bool"	
 
-- name: Set YUM package for python3
-  set_fact:
-    package_to_install: "python34-pip"
-    pip_executable: "pip3"
-    python_executable: "python3"
-  when: 
-    - "use_python3|bool"
-    - ansible_pkg_mgr == 'yum'
+- name: Set YUM package for python3	
+  set_fact:	
+    package_to_install: "{{package_to_install | default('python3-pip')}}"
+    pip_executable: "{{pip_executable | default('pip3')}}"
+    python_executable: "{{python_executable | default('python3')}}"
+  when: 	
+    - "use_python3|bool"	
+    - ansible_pkg_mgr == 'yum'	
     - "not only_python2|bool"
-
+    
 - name: Set package for python2
   set_fact:
-    package_to_install: "python-pip"
-    pip_executable: "pip2"
-    python_executable: "python2"
+    package_to_install: "{{package_to_install | default('python-pip')}}"
+    pip_executable: "{{pip_executable | default('pip2')}}"
+    python_executable: "{{python_executable | default('python2')}}"    
   when: "(not use_python3|bool or only_python2|bool)"
 
 - name: Detect pip installation
   stat: 
-    path: "/usr/bin/{{ pip_executable }}"
+    path: "{{python_executable_path}}{{ pip_executable }}"
   register: pip_installed
 
 - name: Install on Apt based system
@@ -51,10 +55,10 @@
   pip:
     name: pip
     state: latest
-    executable: "{{ pip_executable }}"
+    executable: "{{python_executable_path}}{{ pip_executable }}"
 
 - name: Install virtualenv
   pip:
     name: virtualenv
     state: present
-    executable: "{{ pip_executable }}"
+    executable: "{{python_executable_path}}{{ pip_executable }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,8 @@
   name: "Show use_python3 variable"
 - 
   name: "Set defaults"
-  set_fact: 
-    python_executable_path: "{{python_executable_path | default('/usr/bin/') }}"
+  set_fact:     
+    pip_executable_path: "{{python_executable_path | default('/usr/bin/') }}"
 - 
   name: "Set APT package for python3"
   set_fact: 
@@ -38,7 +38,7 @@
   name: "Detect pip installation"
   register: pip_installed
   stat: 
-    path: "{{python_executable_path}}{{ pip_executable }}"
+    path: "{{pip_executable_path}}{{ pip_executable }}"
 - 
   include: install-apt.yml
   name: "Install on Apt based system"
@@ -54,12 +54,12 @@
 - 
   name: "Upgrade pip with pip"
   pip: 
-    executable: "{{python_executable_path}}{{ pip_executable }}"
+    executable: "{{pip_executable_path}}{{ pip_executable }}"
     name: pip
     state: latest
 - 
   name: "Install virtualenv"
   pip: 
-    executable: "{{python_executable_path}}{{ pip_executable }}"
+    executable: "{{pip_executable_path}}{{ pip_executable }}"
     name: virtualenv
     state: present


### PR DESCRIPTION
I have an issue on ansible linux2 that the pip3 command is not installed, so that I install it on user local bin, also I want to use 3.7 these are some workarounds.

additionally I needed to run this command to get the pip3 to install before running the role.
`python3.7 -m pip install pip --upgrade`



